### PR TITLE
Change from @ to _ on metadata and type attributes

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -44,7 +44,7 @@ Throughout these specifications a set of short terms is being used as described 
 
 - attribute names will be lowercase snake-case names as specified in the RM spec. For example:
     - context : {"start_time": "2016-01-01T00:00Z"}
-- metadata attributes (those that are not also RM attributes) will always be prefixed by a '@'
+- metadata attributes (those that are not also RM attributes) will always be prefixed by a '_'
 - we will use a `_type` attribute to specify RM type which will be upper-case class name from the RM spec:
     {
         "_type": "DV_TEXT",

--- a/apiary.apib
+++ b/apiary.apib
@@ -45,9 +45,9 @@ Throughout these specifications a set of short terms is being used as described 
 - attribute names will be lowercase snake-case names as specified in the RM spec. For example:
     - context : {"start_time": "2016-01-01T00:00Z"}
 - metadata attributes (those that are not also RM attributes) will always be prefixed by a '@'
-- we will use a `@type` attribute to specify RM type which will be upper-case class name from the RM spec:
+- we will use a `_type` attribute to specify RM type which will be upper-case class name from the RM spec:
     {
-        "@type": "DV_TEXT",
+        "_type": "DV_TEXT",
         "value": "Hello world!"
     }
 - null RM attributes will be absent when serialized as JSON
@@ -82,7 +82,7 @@ otherwise default resources will be created automatically by the service.
             {
                 "commit_audit": {
                     "description": "Commit audit description",
-                    "committer": {"@type": "PARTY_IDENTIFIED", ... }
+                    "committer": {"_type": "PARTY_IDENTIFIED", ... }
                 },
                 "ehr_status": { ... },
                 "ehr_access": { ... }
@@ -143,7 +143,7 @@ will be created by the service.
             {
                 "commit_audit": {
                     "description": "Commit audit description",
-                    "committer": {"@type": "PARTY_IDENTIFIED", ... }
+                    "committer": {"_type": "PARTY_IDENTIFIED", ... }
                 },
                 "ehr_status": {...},
                 "ehr_access": {...}
@@ -253,7 +253,7 @@ retained using an alternative audit trail than the usual contribution audit deta
         {
             "commit_audit": {
                 "description": "Commit audit description",
-                "committer": { "@type": "PARTY_IDENTIFIED", 
+                "committer": { "_type": "PARTY_IDENTIFIED", 
                     ... }
             },
             "attestations": { ... }
@@ -1207,9 +1207,9 @@ Retrieve `VERSION` of an `EHR_STATUS` associated with the specified `ehrId` and 
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1246,9 +1246,9 @@ Retrieve `VERSION` of an `EHR_STATUS` associated with the specified `ehrId` and 
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1285,9 +1285,9 @@ Retrieve `VERSION` of an `EHR_STATUS` associated with the specified `ehrId` and 
     + Body (application/json)
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1311,9 +1311,9 @@ Retrieve `VERSION` of an `EHR_STATUS` associated with the specified `ehrId` and 
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1361,9 +1361,9 @@ In case of an update `Match-If` header _might_ be required.
     + Body (application/json)
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1386,9 +1386,9 @@ In case of an update `Match-If` header _might_ be required.
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1506,9 +1506,9 @@ In case of an update `Match-If` header _might_ be required.
     + Body (application/json)
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1531,9 +1531,9 @@ In case of an update `Match-If` header _might_ be required.
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1652,9 +1652,9 @@ In case of an update `Match-If` header _might_ be required.
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1690,9 +1690,9 @@ In case of an update `Match-If` header _might_ be required.
     + Body
 
             {
-                "@type": "COMPOSITION",
+                "_type": "COMPOSITION",
                 "name": {
-                    "@type": "DV_TEXT",
+                    "_type": "DV_TEXT",
                     "value": "Vital Signs"
                 },
                 ...
@@ -1882,9 +1882,9 @@ Gets a complete VERSIONED_COMPOSITION.
             {
                 "commit_audit": {},
                 "data": {
-                    "@type": "COMPOSITION",
+                    "_type": "COMPOSITION",
                     "name": {
-                        "@type": "DV_TEXT",
+                        "_type": "DV_TEXT",
                         "value": "Vital Signs"
                     }
                     ...
@@ -1915,9 +1915,9 @@ Gets a complete VERSIONED_COMPOSITION.
                 "commit_audit": {},
                 "uid": "...",
                 "data": {
-                    "@type": "COMPOSITION",
+                    "_type": "COMPOSITION",
                     "name": {
-                        "@type": "DV_TEXT",
+                        "_type": "DV_TEXT",
                         "value": "Vital Signs"
                     }
                     ...
@@ -1981,9 +1981,9 @@ Gets a complete VERSIONED_COMPOSITION.
                 "commit_audit": {},
                 "uid": "...",
                 "data": {
-                    "@type": "COMPOSITION",
+                    "_type": "COMPOSITION",
                     "name": {
-                        "@type": "DV_TEXT",
+                        "_type": "DV_TEXT",
                         "value": "Vital Signs"
                     }
                     ...
@@ -2026,9 +2026,9 @@ Gets a complete VERSIONED_COMPOSITION.
                 "commit_audit": {},
                 "uid": "...",
                 "data": {
-                    "@type": "COMPOSITION",
+                    "_type": "COMPOSITION",
                     "name": {
-                        "@type": "DV_TEXT",
+                        "_type": "DV_TEXT",
                         "value": "Vital Signs"
                     }
                     ...
@@ -2069,9 +2069,9 @@ offset 0 limit 2
 + Response 200 (application/json)
     
         {
-            "@type": "RESULTSET",
+            "_type": "RESULTSET",
             "@schemaversion": "0.1.0",
-            "@type": "raw",
+            "_type": "raw",
             "@created": "2016-06-22T07:54:04.758+02:00",
             "@generator": "<The resultset generator>",
             "totalResults": 2,
@@ -2088,22 +2088,22 @@ offset 0 limit 2
             "rows": [
                 [
                     {
-                        "@type": "DV_DATE_TIME",
+                        "_type": "DV_DATE_TIME",
                         "value": "2016-06-08T11:02:47+02:00"
                     },
                     {
-                        "@type": "DV_QUANTITY",
+                        "_type": "DV_QUANTITY",
                         "magnitude": 38.0,
                         "units": "°C"
                     }
                 ],
                 [
                     {
-                        "@type": "DV_DATE_TIME",
+                        "_type": "DV_DATE_TIME",
                         "value": "2016-06-05T08:53:36+02:00"
                     },
                     {
-                        "@type": "DV_QUANTITY",
+                        "_type": "DV_QUANTITY",
                         "magnitude": 37.0,
                         "units": "Cel"
                     }


### PR DESCRIPTION
I have changed from @type to _type to specify RM type, and also changed from @ to _ for metadata attributes. 
As we agreed on the API meeting 7.april. 