### PR TITLE
creating sample representation for ehr_status

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -81,6 +81,12 @@ otherwise default resources will be created automatically by the service.
     + Headers
 
             Prefer: return={representation|minimal}
+            
+            
+    + Parameters
+        + subject_id: (HIER_OBJECT_ID, required) - id of the patient associated with the EHR (for EHR_STATUS.subject.external_ref.id)
+        + subject_namespace: (String, optional) - namespece of the type of the subject, if not specified, value is "DEMOGRAPHIC"
+        + subject_type: (String, optional) - type of subject, if not specified, value is "PERSON"
 
     + Body
 
@@ -92,44 +98,8 @@ otherwise default resources will be created automatically by the service.
                 "ehr_status": {                                /* not included attributes that are mandatory in the IM are set by the server, e.g. ehr_status.owner_id will be set when an uid is set for the EHR being created */
                   "_type": "VERSIONED_EHR_STATUS",
                   "uid": "_a_valid_uid_",                      /* UUID or OID, UUID preferred */
-                  "version": {
-                    "_type": "ORIGINAL_VERSION",               /* Use IMPORTED_VERSION if this is a copy from another server */
-                    "uid": "_ehr_status_uid_::_system_id_::1", /* _system_id_ is the ID of the system from which the EHR was created */
-                    "data": {
-                      "_type": "EHR_STATUS",
-                      "subject": {
-                        "external_ref": {
-                          "namespace": "DEMOGRAPHIC",
-                          "type": "PERSON",
-                          "id": {
-                            "_type": "HIER_OBJECT_ID",
-                            "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
-                          }
-                        }
-                      }
-                      "is_queryable": true,
-                      "is_modifiable": true,
-                      "other_details": {                       /* optional, ITEM_STRUCTURE */
-                        "_type": "ITEM_TREE",
-                        "items": {
-                          ...
-                        }
-                      }
-                    },
-                    "commit_audit": {                          /* the time committed attribute is set by the server */
-                      "system_id": "_a_string_id_",            /* same as the container version.uid.system_id */
-                      "change_type": {
-                        "value": "creation",
-                        "terminology_id": {
-                          "value": "openehr"
-                        },
-                        "code_string": "249"
-                      },
-                      "description": "optional description"
-                    }
-                  }
-                },
-                "ehr_access": { ... }
+                  "time_created": "YYYYMMDDThhmmss,SSS(Z|[+-]hhmm)", /* ISO8601 e.g. 20170801T010646,000+0000 or 20170801T010646,000Z */
+                }
             }
 
 + Response 201 (application/json)
@@ -355,20 +325,32 @@ The `versionSelector` parameter may be an ISO8601 datetime string or symbolic va
     + Body
 
             {
-                "uid": "..",
-                "subject": {
-                    “external_ref”: {
-                        “namespace”: “DEMOGRAPHIC”,
-                        “type”: “PERSON”,
-                        “id”: {
-                            “@type”: “HIER_OBJECT_ID”,
-                            “value”: “12341234-1234-1234-123412”
-                        }
-                    }
-                },
-                "is_queryable": true,
-                "is_modifiable": true,
-                "other_details": {} // PP: make it optional, do not include if there is no data, in the specs can be null, also value null can be used in json.
+              "_type": "EHR_STATUS",
+              "uid": "...",                                /* LOCATABLE */
+              "archetype_node_id": "",                     /* LOCATABLE */
+              "name": "",                                  /* LOCATABLE */
+              "archetype_details": {                       /* LOCATABLE */
+                "archetype_id": "...",
+                "rm_version": "1.0.3",
+              },
+              "subject": {
+                "external_ref": {
+                  "namespace": "DEMOGRAPHIC",
+                  "type": "PERSON",
+                  "id": {
+                    "_type": "HIER_OBJECT_ID",
+                    "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                  }
+                }
+              }
+              "is_queryable": true,
+              "is_modifiable": true,
+              "other_details": {                           /* optional, ITEM_STRUCTURE, archetypable */
+                "_type": "ITEM_TREE",
+                "items": {
+                  ...
+                }
+              }
             }
 
 
@@ -405,11 +387,32 @@ Retrieve the version of the `EHR_STATUS` associated with the specified `ehrId` a
     + Body
 
             {
-                "uid": "..",
-                "subject": {},
-                "is_queryable": true,
-                "is_modifiable": true,
-                "other_details": {}
+              "_type": "EHR_STATUS",
+              "uid": "...",                                /* LOCATABLE */
+              "archetype_node_id": "",                     /* LOCATABLE */
+              "name": "",                                  /* LOCATABLE */
+              "archetype_details": {                       /* LOCATABLE */
+                "archetype_id": "...",
+                "rm_version": "1.0.3",
+              },
+              "subject": {
+                "external_ref": {
+                  "namespace": "DEMOGRAPHIC",
+                  "type": "PERSON",
+                  "id": {
+                    "_type": "HIER_OBJECT_ID",
+                    "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                  }
+                }
+              }
+              "is_queryable": true,
+              "is_modifiable": true,
+              "other_details": {                           /* optional, ITEM_STRUCTURE, archetypable */
+                "_type": "ITEM_TREE",
+                "items": {
+                  ...
+                }
+              }
             }
 
 
@@ -451,10 +454,32 @@ The response will contain the updated `EHR_STATUS` resource when the `Prefer` he
     + Body
 
             {
-                "subject": {},
-                "is_queryable": true,
-                "is_modifiable": true,
-                "other_details": {}
+              "_type": "EHR_STATUS",
+              "uid": "...",                                  /* LOCATABLE */
+              "archetype_node_id": "",                       /* LOCATABLE */
+              "name": "",                                    /* LOCATABLE */
+              "archetype_details": {                         /* LOCATABLE */
+                "archetype_id": "...",
+                "rm_version": "1.0.3",
+              },
+              "subject": {
+                "external_ref": {
+                  "namespace": "DEMOGRAPHIC",
+                  "type": "PERSON",
+                  "id": {
+                    "_type": "HIER_OBJECT_ID",
+                    "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                  }
+                }
+              }
+              "is_queryable": true,
+              "is_modifiable": true,
+              "other_details": {                             /* optional, ITEM_STRUCTURE, archetypable */
+                "_type": "ITEM_TREE",
+                "items": {
+                  ...
+                }
+              }
             }
 
 + Response 200
@@ -470,11 +495,32 @@ The response will contain the updated `EHR_STATUS` resource when the `Prefer` he
     + Body
 
             {
-                "uid": "...",
-                "subject": {},
-                "is_queryable": true,
-                "is_modifiable": true,
-                "other_details": {}
+              "_type": "EHR_STATUS",
+              "uid": "...",                                  /* LOCATABLE */
+              "archetype_node_id": "",                       /* LOCATABLE */
+              "name": "",                                    /* LOCATABLE */
+              "archetype_details": {                         /* LOCATABLE */
+                "archetype_id": "...",
+                "rm_version": "1.0.3",
+              },
+              "subject": {
+                "external_ref": {
+                  "namespace": "DEMOGRAPHIC",
+                  "type": "PERSON",
+                  "id": {
+                    "_type": "HIER_OBJECT_ID",
+                    "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                  }
+                }
+              }
+              "is_queryable": true,
+              "is_modifiable": true,
+              "other_details": {                             /* optional, ITEM_STRUCTURE, archetypable */
+                "_type": "ITEM_TREE",
+                "items": {
+                  ...
+                }
+              }
             }
 
 + Response 204
@@ -533,16 +579,41 @@ Retrieve `VERSIONED_EHR_STATUS` associated with an EHR specified by `ehrId` incl
     + Body
 
             {
-                "uid": "xxx",
-                "owner_id": "{ehrId}",
-                "time_created": "ISO8601 timestamp",
-                "revision_history": 
-                    { "items": [
-                        { "version_id": "",
-                            "audits" : [ {...} ]
-                        }]
+               "_type": "VERSIONED_EHR_STATUS",
+               "uid": "_a_valid_uid_",                     /* UUID or OID, UUID preferred */
+               "owner_id": "{ehrId}",
+               "time_created": "DV_DATE_TIME",             /* ISO8601 YYYYMMDDThhmmss,SSS(Z|[+-]hhmm) e.g. 20170801T010646,000+0000 or 20170801T010646,000Z */
+               "revision_history": {
+                 "items": [
+                   {
+                     "version_id": "OBJECT_VERSION_ID",    /* object_id::creating_system_id::version_tree_id */
+                     "audits": [
+                       {
+                         "system_id": "String",
+                         "time_committed": "DV_DATE_TIME",
+                         "change_type": {
+                           "value": "String",              /* value from openehr terminoogy, change_type http://openehr.org/releases/1.0.2/architecture/terminology.pdf */
+                           "defining_code": {
+                             "terminology_id": {
+                               "value": "openehr"
+                             },
+                             "code_stirng": "String"
+                           }
+                         },
+                         "desription": {
+                           "value": "String"
+                         }
+                       },
+                       {...},
+                       {...}
+                     ]
+                   },
+                   {...},
+                   {...}
+                 ]
+               }
             }
-            }
+                  
 
 + Response 400
     `400 Bad Request` is returned when the request is invalid such as an invalid `ehrId` value.
@@ -584,16 +655,61 @@ The `versionSelector` parameter may be an ISO8601 datetime string or symbolic va
     + Body
 
             {
-                "contribution": {...},
-                "signature": "...",
-                "commit_audit": {...},
-                "uid": "...",
-                "data": {
-                    "subject": {...},
-                    "is_modifiable": "...",
-                    "is_queryable": "...",
-                    "other_details": {...}
+              "_type": "ORIGINAL_VERSION",                 /* Use IMPORTED_VERSION if this is a copy from another server */
+              "uid": "OBJECT_VERSION_ID",                  /* _ehr_status_uid_::_system_id_::1 _system_id_ is the ID of the system from which the EHR was created */
+              "contribution": {                            /* does not include reference to other versions, even that is mandatory in the IM */
+                "uid": "HIER_OBJECT_ID",
+                "audit": {
+                  "system_id": "String",
+                  "time_committed": "DV_DATE_TIME",
+                  "description": "String"                  /* optional */
                 }
+              },
+              "signature": "String",                       /* optional */
+              "data": {
+                "_type": "EHR_STATUS",
+                "subject": {
+                  "external_ref": {
+                    "namespace": "DEMOGRAPHIC",
+                    "type": "PERSON",
+                    "id": {
+                      "_type": "HIER_OBJECT_ID",
+                      "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                    }
+                  }
+                }
+                "is_queryable": true,
+                "is_modifiable": true,
+                "other_details": {                         /* optional, ITEM_STRUCTURE, archetypable */
+                  "_type": "ITEM_TREE",
+                  "items": {
+                    ...
+                  }
+                }
+              },
+              "commit_audit": {                            /* the time committed attribute is set by the server */
+                "system_id": "_a_string_id_",              /* same as the container version.uid.system_id */
+                "change_type": {
+                  "value": "creation",
+                  "terminology_id": {
+                    "value": "openehr"
+                  },
+                  "code_string": "249"
+                },
+                "description": "optional description"
+              },
+              "attestations": [
+                {
+                  "system_id": "String",
+                  "time_committed": "DV_DATE_TIME",
+                  "description": "String"                  /* optional */
+                  "reason": "DV_TEXT",
+                  "proof": "String",                       /* optional */
+                  "is_pending": "Boolean"
+                },
+                {...},
+                {...}
+              ]
             }
 
 + Response 400
@@ -630,16 +746,61 @@ Retrieve `VERSION` of an `EHR_STATUS` associated with the specified `ehrId` and 
     + Body
 
             {
-                "contribution": {...},
-                "signature": "...",
-                "commit_audit": {...},
-                "uid": "...",
-                "data": {
-                    "subject": {...},
-                    "is_modifiable": "...",
-                    "is_queryable": "...",
-                    "other_details": {...}
+              "_type": "ORIGINAL_VERSION",                 /* Use IMPORTED_VERSION if this is a copy from another server */
+              "uid": "OBJECT_VERSION_ID",                  /* _ehr_status_uid_::_system_id_::1 _system_id_ is the ID of the system from which the EHR was created */
+              "contribution": {                            /* does not include reference to other versions, even that is mandatory in the IM */
+                "uid": "HIER_OBJECT_ID",
+                "audit": {
+                  "system_id": "String",
+                  "time_committed": "DV_DATE_TIME",
+                  "description": "String"                  /* optional */
                 }
+              },
+              "signature": "String",                       /* optional */
+              "data": {
+                "_type": "EHR_STATUS",
+                "subject": {
+                  "external_ref": {
+                    "namespace": "DEMOGRAPHIC",
+                    "type": "PERSON",
+                    "id": {
+                      "_type": "HIER_OBJECT_ID",
+                      "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                    }
+                  }
+                }
+                "is_queryable": true,
+                "is_modifiable": true,
+                "other_details": {                         /* optional, ITEM_STRUCTURE, archetypable */
+                  "_type": "ITEM_TREE",
+                  "items": {
+                    ...
+                  }
+                }
+              },
+              "commit_audit": {                            /* the time committed attribute is set by the server */
+                "system_id": "_a_string_id_",              /* same as the container version.uid.system_id */
+                "change_type": {
+                  "value": "creation",
+                  "terminology_id": {
+                    "value": "openehr"
+                  },
+                  "code_string": "249"
+                },
+                "description": "optional description"
+              },
+              "attestations": [
+                {
+                  "system_id": "String",
+                  "time_committed": "DV_DATE_TIME",
+                  "description": "String"                  /* optional */
+                  "reason": "DV_TEXT",
+                  "proof": "String",                       /* optional */
+                  "is_pending": "Boolean"
+                },
+                {...},
+                {...}
+              ]
             }
 
 + Response 400

--- a/apiary.apib
+++ b/apiary.apib
@@ -89,7 +89,46 @@ otherwise default resources will be created automatically by the service.
                     "description": "Commit audit description",
                     "committer": {"_type": "PARTY_IDENTIFIED", ... }
                 },
-                "ehr_status": { ... },
+                "ehr_status": {                                /* not included attributes that are mandatory in the IM are set by the server, e.g. ehr_status.owner_id will be set when an uid is set for the EHR being created */
+                  "_type": "VERSIONED_EHR_STATUS",
+                  "uid": "_a_valid_uid_",                      /* UUID or OID, UUID preferred */
+                  "version": {
+                    "_type": "ORIGINAL_VERSION",               /* Use IMPORTED_VERSION if this is a copy from another server */
+                    "uid": "_ehr_status_uid_::_system_id_::1", /* _system_id_ is the ID of the system from which the EHR was created */
+                    "data": {
+                      "_type": "EHR_STATUS",
+                      "subject": {
+                        "external_ref": {
+                          "namespace": "DEMOGRAPHIC",
+                          "type": "PERSON",
+                          "id": {
+                            "_type": "HIER_OBJECT_ID",
+                            "value": "_valid_root_uid_::_extension_" /* root can be UUID or OID, UUID preferred '::_extension_' is optional */
+                          }
+                        }
+                      }
+                      "is_queryable": true,
+                      "is_modifiable": true,
+                      "other_details": {                       /* optional, ITEM_STRUCTURE */
+                        "_type": "ITEM_TREE",
+                        "items": {
+                          ...
+                        }
+                      }
+                    },
+                    "commit_audit": {                          /* the time committed attribute is set by the server */
+                      "system_id": "_a_string_id_",            /* same as the container version.uid.system_id */
+                      "change_type": {
+                        "value": "creation",
+                        "terminology_id": {
+                          "value": "openehr"
+                        },
+                        "code_string": "249"
+                      },
+                      "description": "optional description"
+                    }
+                  }
+                },
                 "ehr_access": { ... }
             }
 


### PR DESCRIPTION
ehr_status is used but has not defined representation in JSON.

This is an exercise trying to add that representation following the IM. Detected many issues that will cause implementation problems:

1. deep structure: if this is not simplified for the REST API, a huge structure is needed to represent few data points, and deep knowledge of the IM is needed in order to create such structure.

2. version data is included: since this follows the IM, but for POST /ehrs most of the data can be set by the server, this translates responsibility of having some versioning knowledge on the client side, like the default version number or the system_id

3. some data points are set by the server: this should be clear for the client, and makes the definition of the API over complicated. Again, deep knowledge of the IM is needed to understand what is included by the client and what is set by the server.

4. invalid representation because of data set by the server: if the representation is valid with respect to the IM specs, then the mandatory fields should have non empty values, but since some values are set by the server, like EHR_STATUS.ownder_id (is the EHR.uid), since the EHR.uid could be set by the server. If that is not set by the server, then the client should also assign uids to EHRs and set the EHR_STATUS.owner_id on the client side, translating complexity to the client.

This is my analysis for just one object that wasn't defined, I can see we will these issues by defining other objects if we follow the IM on the API representaions.