### PR TITLE
Changed all qualified-query-name to qualified_query_name

### DIFF
--- a/REST_API/includes/query.apib
+++ b/REST_API/includes/query.apib
@@ -55,9 +55,9 @@ Warning: URIs in practice have a length restriction. Long AQLs in parameter `q` 
             }
 
 
-### Execute stored query [GET /query/{qualified-query-name}/{version}{?offset,fetch,query_parameter}]
+### Execute stored query [GET /query/{qualified_query_name}/{version}{?offset,fetch,query_parameter}]
 
-Execute a stored query with the supplied qualified-query-name.
+Execute a stored query with the supplied qualified_query_name.
 
 All query parameters found except "offset" and "fetch" are sent to the query execution engine.
 For parameters in AQL queries, see `http://www.openehr.org/releases/QUERY/latest/docs/AQL/AQL.html#_parameters`.
@@ -69,7 +69,7 @@ Will pass parameters `temperature_from` and `temperature_unit` to the underlying
 
 + Parameters
 
-    +   `qualified-query-name` (string) - qualified query name to be executed. It may be formatted as
+    +   `qualified_query_name` (string) - qualified query name to be executed. It may be formatted as
         `<namespace>::<query-name>`, this way we can separate queries by domain, etc.
         Example qualified query name: `org.openehr::compositions`
     +   version (string, optional) - SEMVER style (major.minor.patch) version prefix. If only major or major.minor are used then the latest version with
@@ -92,16 +92,16 @@ Will pass parameters `temperature_from` and `temperature_unit` to the underlying
             }
 
 
-### Execute stored query [POST /query/{qualified-query-name}/{version}]
+### Execute stored query [POST /query/{qualified_query_name}/{version}]
 
-Execute a stored query with the supplied qualified-query-name.
+Execute a stored query with the supplied qualified_query_name.
 
 The absence of the http header 'ehr_id' means that the stored query or request parameters MAY contain a list of several ehr_ids or be
 unconstrained regarding ehr_id (e.g. population queries).
 
 + Parameters
 
-    +   `qualified-query-name` (string) - qualified query name to be executed. It may be formatted as
+    +   `qualified_query_name` (string) - qualified query name to be executed. It may be formatted as
         `<namespace>::<query-name>`, this way we can separate queries by domain, etc.
         Example qualified query name: `org.openehr::compositions`
     +   version (string) - SEMVER style (major.minor.patch) version prefix. If only major or major.minor are used then the latest version with

--- a/REST_API/includes/query_definition.apib
+++ b/REST_API/includes/query_definition.apib
@@ -12,9 +12,9 @@ system must use the latest version with the supplied prefix.
 
 Management of stored queries is done using resources starting /definition/query described here.
 
-### List stored queries [GET /definition/query/{qualified-query-name}]
+### List stored queries [GET /definition/query/{qualified_query_name}]
 
-Parameter `qualified-query-name` is optional. If omitted they are treated as “wildcards” in the search
+Parameter `qualified_query_name` is optional. If omitted they are treated as “wildcards” in the search
 
 Examples:
 *   `GET /definition/query/org.openehr` will list all versions of all
@@ -23,7 +23,7 @@ Examples:
     list all versions of the query named `org.openehr::compositions`
 
 + Parameters
-    +   `qualified-query-name` (string)
+    +   `qualified_query_name` (string)
 
 + Response 200 (application/json) 
 
@@ -48,13 +48,13 @@ Examples:
 
 
 
-### Store a query [PUT /query/{qualified-query-name}/{version}{?type}]
+### Store a query [PUT /query/{qualified_query_name}/{version}{?type}]
 
 Store a new query on the system.
 
 + Parameters
 
-    +   `qualified-query-name` (string, required) - query name
+    +   `qualified_query_name` (string, required) - query name
     +   version - version number following the http://semver.org/ conventions
     +   type (string, optional) - indicating the query language/type (presently AQL, but future additions possible)
  
@@ -76,7 +76,7 @@ Store a new query on the system.
 
     + Headers
 
-            Location: /query/{qualified-query-name}/{version}
+            Location: /query/{qualified_query_name}/{version}
 
 + Response 400
 
@@ -91,11 +91,11 @@ Store a new query on the system.
 
     + Body
 
-### Get stored query and info/metadata [GET /query/{qualified-query-name}/{version}]
+### Get stored query and info/metadata [GET /query/{qualified_query_name}/{version}]
 
 + Parameters
     
-    +   `qualified-query-name` (string) - query name
+    +   `qualified_query_name` (string) - query name
     +   version (string) - version number following the http://semver.org/ conventions
 
 + Response 200 (application/json)


### PR DESCRIPTION
Underline is used for variables in the spec. For qualified query name a dash is used. Changed this to align with the rest of variables. 